### PR TITLE
Expose loader configuration

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,5 @@ class PagesController < ApplicationController
   end
 
   def click
-    #code
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,1 +1,2 @@
+import "expose-loader?jQuery!jquery";
 import "bootstrap";

--- a/app/views/pages/click.js.erb
+++ b/app/views/pages/click.js.erb
@@ -1,3 +1,5 @@
+// default to jQuery is not working
 document.querySelector('#feedback').innerHTML = "jQuery don't work"
 
-$("#feedback").html = "jQuery works"
+// if jQuery works overwrite feedback
+$("#feedback").html("jQuery works")

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,7 @@
 <h1>Pages#home</h1>
 <p>Find me in app/views/pages/home.html.erb</p>
-<%= link_to "Test Unobtrusive JavaScript", click_path,remote: :true, class: "btn btn-primary" %>
+<%= link_to "Test Unobtrusive JavaScript",
+    click_path,
+    remote: true,
+    class: "btn btn-primary" %>
 <div id="feedback"></div>

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,12 +1,17 @@
-const { environment } = require('@rails/webpacker')
+const { environment } = require("@rails/webpacker");
 
-// Bootstrap 3 has a dependency over jQuery:
-const webpack = require('webpack')
-environment.plugins.prepend('Provide',
-  new webpack.ProvidePlugin({
-    $: 'jquery',
-    jQuery: 'jquery'
-  })
-)
+environment.loaders.prepend("jquery", {
+  test: require.resolve("jquery"),
+  use: [
+    {
+      loader: "expose-loader",
+      options: "jQuery"
+    },
+    {
+      loader: "expose-loader",
+      options: "$"
+    }
+  ]
+});
 
-module.exports = environment
+module.exports = environment;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "3.5",
     "bootstrap": "3",
+    "expose-loader": "^0.7.5",
     "jquery": "^3.3.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1997,6 +1997,10 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
+expose-loader@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/expose-loader/-/expose-loader-0.7.5.tgz#e29ea2d9aeeed3254a3faa1b35f502db9f9c3f6f"
+
 express@^4.16.2:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"


### PR DESCRIPTION
This is a proposed solution to make $ global when using webpack as it used to be with sprockets.

it requires a new pack `yarn add expose-loarder`